### PR TITLE
function runner script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ wheels/
 /.envrc
 /.python-version
 /CLAUDE.md
+/.DS_Store

--- a/src/groundhog_hpc/app/main.py
+++ b/src/groundhog_hpc/app/main.py
@@ -1,8 +1,13 @@
-import time
+import json
 from pathlib import Path
 
-import globus_compute_sdk as gc
 import typer
+
+from groundhog_hpc.runner import script_to_callable
+from groundhog_hpc.settings import (
+    DEFAULT_ENDPOINTS,
+    DEFAULT_WALLTIME_SEC,
+)
 
 app = typer.Typer()
 
@@ -13,69 +18,63 @@ CONFIG = {
     # "account": "cis250223",  # diamond
     "account": "cis250461",  # garden
     # "qos": "gpu",
-    "worker_init": "pip show -qq uv || pip install uv",  # install uv in the worker environment
 }
-
-# Available endpoints
-ENDPOINTS = {
-    "anvil-mep": "5aafb4c1-27b2-40d8-a038-a0277611868f",  # official anvil multi-user-endpoint
-    # "mep-local": "f6ce8cef-eee0-4f9d-bb04-f644dbff0acf",  # started manually on login node
-    # "mep-slurm": "b4124d73-0c27-4c6a-a193-89e052a86238",  # slurm provider
-    # "default-uep": "d7c1047b-a6f6-407c-9293-713ecd603567",  # default user endpoint
-}
-
-
-def run_code(contents: str, endpoint: str, config: dict = CONFIG) -> str:
-    cmd = """
-cat > /tmp/temp_script.py << 'EOF'
-{contents}
-EOF
-$(python -c 'import uv; print(uv.find_uv_bin())') run /tmp/temp_script.py
-"""
-    shell_fn = gc.ShellFunction(cmd=cmd, walltime=60)
-    with gc.Executor(endpoint, user_endpoint_config=config) as executor:
-        future = executor.submit(shell_fn, contents=contents)
-
-        while not future.done():
-            typer.echo(".", nl=False)
-            time.sleep(1)
-
-        typer.echo()  # New line after progress dots
-        shell_result = future.result()
-
-    return shell_result.stdout
 
 
 @app.command(no_args_is_help=True)
 def run(
-    script: Path = typer.Argument(..., help="Python script to run on the endpoint"),
-    endpoint: str = typer.Option(
-        "anvil-mep",
-        help="Target endpoint (anvil-mep, or UUID)",
+    script: Path = typer.Argument(
+        ..., help="Python script with dependencies to deploy to the endpoint"
     ),
-    verbose: bool = typer.Option(False, "--verbose", help="Verbose output"),
+    function: str = typer.Argument(..., help="Name of function in script to run"),
+    datapath: Path = typer.Argument(None, help="Local path to input data"),
+    endpoint: str = typer.Option(
+        "anvil",
+        help="Target globus compute multi-user endpoint (default 'anvil')",
+    ),
+    quiet: bool = typer.Option(False, "--verbose", help="Disable verbose output"),
 ):
     """Run a Python script on a Globus Compute endpoint."""
 
-    endpoint_id = ENDPOINTS.get(endpoint, endpoint)
-    config = CONFIG.copy()
+    endpoint = DEFAULT_ENDPOINTS.get(endpoint, DEFAULT_ENDPOINTS["anvil"])
 
     script = script.resolve()
     if not script.exists():
         typer.echo(f"Error: Script '{script}' not found", err=True)
         raise typer.Exit(1)
 
+    args, kwargs = ((), {})
+    if datapath:
+        datapath = datapath.resolve()
+        if not datapath.exists():
+            typer.echo(f"Error: datapath '{datapath}' not found", err=True)
+            raise typer.Exit(1)
+        try:
+            args, kwargs = json.loads(datapath.read_text())
+        except json.JSONDecodeError:
+            typer.echo(f"Error: failed to load data at {datapath}.")
+            typer.echo(
+                "Note: data should be json array with two elements: a positonal args array and a kwargs object."
+            )
+            raise typer.Exit(1)
+
     contents = script.read_text()
 
-    if verbose:
-        typer.echo(f"Running script on endpoint: {endpoint_id}")
+    if not quiet:
+        typer.echo(f"Running script on endpoint: {endpoint}")
         typer.echo(f"Script contents:\n{contents}\n")
 
     try:
-        t0 = time.time()
-        result = run_code(contents, endpoint_id, config)
+        run = script_to_callable(
+            contents,
+            function,
+            endpoint=endpoint,
+            user_endpoint_config=CONFIG,
+            walltime=DEFAULT_WALLTIME_SEC,
+            verbose=not quiet,
+        )
+        result = run(*args, **kwargs)
         typer.echo(result)
-        typer.echo(f"Time taken: {time.time() - t0:.2f} seconds")
     except Exception as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)

--- a/src/groundhog_hpc/runner.py
+++ b/src/groundhog_hpc/runner.py
@@ -1,0 +1,120 @@
+import time
+from hashlib import sha1
+from typing import Callable
+from uuid import UUID
+
+import globus_compute_sdk as gc
+
+from groundhog_hpc.serialization import deserialize, serialize
+from groundhog_hpc.settings import DEFAULT_USER_CONFIG
+
+SHELL_COMMAND_TEMPLATE = """
+mkdir -p /tmp/groundhog/{script_hash}
+cat > /tmp/groundhog/{script_hash}/script.py << 'EOF'
+{contents}
+EOF
+cat > /tmp/groundhog/{script_hash}/payload << 'END'
+{payload}
+END
+$(python -c 'import uv; print(uv.find_uv_bin())') run /tmp/groundhog/{script_hash}/script.py {function_name} < /tmp/groundhog/{script_hash}/payload > /tmp/groundhog/{script_hash}/run.stdout 2> /tmp/groundhog/{script_hash}/run.stderr
+touch /tmp/groundhog/{script_hash}/results.out
+cat /tmp/groundhog/{script_hash}/results.out
+"""
+
+
+def script_to_callable(
+    user_script: str,
+    function_name: str,
+    endpoint: str,
+    walltime: int,
+    user_endpoint_config: dict | None = None,
+    verbose=True,
+) -> Callable:
+    """Create callable corresponding to the named function from a user's script.
+
+    The created function accepts the same arguments as the original named function, but
+    dispatches to a shell function on the remote endpoint.
+
+    The function must expect json-serializable input and return json-serializable output.
+    """
+
+    config = DEFAULT_USER_CONFIG.copy()
+    config.update(user_endpoint_config or {})
+
+    script_hash = _script_hash_prefix(user_script)
+    contents = _inject_script_boilerplate(
+        user_script, function_name, f"/tmp/groundhog/{script_hash}/results.out"
+    )
+
+    if verbose:
+        print(f"{script_hash=}")
+
+    def run(*args, **kwargs):
+        shell_fn = gc.ShellFunction(cmd=SHELL_COMMAND_TEMPLATE, walltime=walltime)
+        payload = serialize((args, kwargs))
+
+        with gc.Executor(UUID(endpoint), user_endpoint_config=config) as executor:
+            t0 = time.time()
+            future = executor.submit(
+                shell_fn,
+                script_hash=script_hash,
+                contents=contents,
+                function_name=function_name,
+                payload=payload,
+            )
+
+            if verbose:
+                # show progress
+                i = 0
+                while not future.done():
+                    i += 1
+                    print(".", end="", flush=True)
+                    if i % 30 == 0:
+                        print("\n")
+                    time.sleep(1)
+                elapsed = time.time() - t0
+                print(f"\nRan in {elapsed:.4f} seconds")
+
+            shell_result: gc.ShellResult = future.result()
+            try:
+                if not shell_result.stdout:
+                    return None
+                return deserialize(shell_result.stdout)
+            except Exception:
+                print(shell_result.cmd)
+                print(shell_result.stdout)
+                print(shell_result.stderr)
+                print(shell_result.exception_name)
+                raise
+
+    return run
+
+
+def _script_hash_prefix(contents: str, length=8) -> str:
+    return str(sha1(bytes(contents, "utf-8")).hexdigest()[:length])
+
+
+def _inject_script_boilerplate(
+    user_script: str, function_name: str, outfile_path: str
+) -> str:
+    assert "__main__" not in user_script, (
+        "invalid user script: can't define custom `__main__` logic"
+    )
+    # TODO better validation errors
+    # or see if we can use runpy to explicitly set __name__ (i.e. "__groundhog_main__")
+
+    script = f"""
+{user_script}
+if __name__ == "__main__":
+    import json
+    import sys
+
+    _, function_name, payload_path = sys.argv
+    with open(payload_path, 'r') as f_in:
+        args, kwargs = json.load(f_in)
+
+    results = {function_name}(*args, **kwargs)
+    with open({outfile_path}, 'w+') as f_out:
+        json.dump(results, f_out)
+"""
+    return script

--- a/src/groundhog_hpc/serialization.py
+++ b/src/groundhog_hpc/serialization.py
@@ -1,0 +1,10 @@
+import json
+from typing import Any
+
+
+def serialize(obj: Any) -> str:
+    return json.dumps(obj)
+
+
+def deserialize(payload: str) -> Any:
+    return json.loads(payload)

--- a/src/groundhog_hpc/settings.py
+++ b/src/groundhog_hpc/settings.py
@@ -1,0 +1,16 @@
+DEFAULT_USER_CONFIG = {
+    # "container_type": "singularity",
+    # "container_uri": "file:///users/x-oprice/groundhog/singularity/groundhog.sif",
+    # "container_cmd_options": "-B /home/x-oprice/.uv:/root/.uv",
+    # "account": "cis250223",  # diamond
+    # "account": "cis250461",  # garden
+    # "qos": "gpu",
+    "worker_init": "pip show -qq uv || pip install uv",  # install uv in the worker environment
+}
+
+DEFAULT_ENDPOINTS = {
+    "anvil": "5aafb4c1-27b2-40d8-a038-a0277611868f",  # official anvil multi-user-endpoint
+}
+
+
+DEFAULT_WALLTIME_SEC = 60


### PR DESCRIPTION
closes #5 

This PR updates the `hog run` command so that it can dispatch input data (must be json) to functions defined in the user's code, instead of just running their code as a script. 

for example, running 
`$ hog run hello_functions.py hello_arguments my_data.json` 

when `hello_functions.py` is the following script: 
```python
# /// script
# requires-python = "==3.12"
# dependencies = []
# ///
"""
sample script for `hog run` to execute on the remote globus compute endpoint with uv
"""
def hello_arguments(one, two, three, key=None):
    if key:
        return {key: [three, two, one], "hello": "world"}
    return ["hello", three, two, one, "world"]
```

and `my_data.json` is: 
```json
[
    [1,2,3],
    {"key": "word"}
]
```

then `{'word': [3, 2, 1], 'hello': 'world'}` is printed to the console. 

I can also use the `script_to_callable` helper from a repl to create a regular python function 
