### PR TITLE
feat: better error messages from remote endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,10 @@ name = "groundhog-hpc"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 dependencies = [
     "globus-compute-sdk>=3.12.0",
     "typer>=0.16.1",
-    "uv>=0.8.15",
 ]
 
 [project.scripts]

--- a/src/groundhog_hpc/app/main.py
+++ b/src/groundhog_hpc/app/main.py
@@ -3,17 +3,9 @@ from pathlib import Path
 
 import typer
 
+from groundhog_hpc.errors import RemoteExecutionError
+
 app = typer.Typer()
-
-CONFIG = {
-    # "container_type": "singularity",
-    # "container_uri": "file:///users/x-oprice/groundhog/singularity/groundhog.sif",
-    # "container_cmd_options": "-B /home/x-oprice/.uv:/root/.uv",
-    # "account": "cis250223",  # diamond
-    "account": "cis250461",  # garden
-    # "qos": "gpu",
-}
-
 
 @app.command(no_args_is_help=True)
 def run(
@@ -49,6 +41,10 @@ def run(
 
         result = script_namespace[function]()
         typer.echo(result)
+    except RemoteExecutionError as e:
+        typer.echo(f"Remote execution failed (exit code {e.returncode}):", err=True)
+        typer.echo(e.stderr, err=True)
+        raise typer.Exit(1)
     except Exception as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)

--- a/src/groundhog_hpc/errors.py
+++ b/src/groundhog_hpc/errors.py
@@ -1,4 +1,4 @@
-"""Custom exceptions for Groundhog HPC."""
+"""Custom exceptions for Groundhog."""
 
 
 class RemoteExecutionError(Exception):

--- a/src/groundhog_hpc/errors.py
+++ b/src/groundhog_hpc/errors.py
@@ -1,0 +1,21 @@
+"""Custom exceptions for Groundhog HPC."""
+
+
+class RemoteExecutionError(Exception):
+    """Raised when a remote function execution fails on the Globus Compute endpoint.
+
+    Attributes:
+        message: Human-readable error description
+        stderr: Standard error output from the remote execution
+        returncode: Exit code from the remote process
+    """
+
+    def __init__(self, message: str, stderr: str, returncode: int):
+        # Remove trailing WARNING lines that aren't part of the traceback
+        lines = stderr.strip().split("\n")
+        while lines and lines[-1].startswith("WARNING:"):
+            lines.pop()
+
+        self.stderr = "\n".join(lines)
+        self.returncode = returncode
+        super().__init__(message)

--- a/src/groundhog_hpc/runner.py
+++ b/src/groundhog_hpc/runner.py
@@ -57,8 +57,12 @@ def script_to_callable(
 
             shell_result: gc.ShellResult = future.result()
 
-            if not shell_result.stdout:
-                return None
+            if shell_result.returncode != 0:
+                raise RemoteExecutionError(
+                    message=f"Remote execution failed with exit code {shell_result.returncode}",
+                    stderr=shell_result.stderr,
+                    returncode=shell_result.returncode,
+                )
 
             return deserialize(shell_result.stdout)
 

--- a/uv.lock
+++ b/uv.lock
@@ -284,7 +284,6 @@ source = { editable = "." }
 dependencies = [
     { name = "globus-compute-sdk" },
     { name = "typer" },
-    { name = "uv" },
 ]
 
 [package.dev-dependencies]
@@ -298,7 +297,6 @@ dev = [
 requires-dist = [
     { name = "globus-compute-sdk", specifier = ">=3.12.0" },
     { name = "typer", specifier = ">=0.16.1" },
-    { name = "uv", specifier = ">=0.8.15" },
 ]
 
 [package.metadata.requires-dev]
@@ -718,32 +716,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
-]
-
-[[package]]
-name = "uv"
-version = "0.8.15"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/7c/ab905b0425f88842f3d8e5da50491524f45a231b7a3dc9c988608162adb2/uv-0.8.15.tar.gz", hash = "sha256:8ea57b78be9f0911a2a50b6814d15aec7d1f8aa6517059dc8250b1414156f93a", size = 3602914, upload-time = "2025-09-03T14:32:15.552Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/1d/794352a01b40f2b0a0abe02f4f020219b3f59ee6ed900561be3b2b47a82b/uv-0.8.15-py3-none-linux_armv6l.whl", hash = "sha256:f02e6b8be08b840f86b8d5997b658b657acdda95bc216ecf62fce6c71414bdc7", size = 20136396, upload-time = "2025-09-03T14:31:30.404Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/89/528f01cff01eb8d10dd396f437656266443e399dda2fe4787b2cf6983698/uv-0.8.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b0461bb1ad616c8bcb59c9b39ae9363245ca33815ebb1d11130385236eca21b9", size = 19297422, upload-time = "2025-09-03T14:31:34.412Z" },
-    { url = "https://files.pythonhosted.org/packages/94/03/532af32a64d162894a1daebb7bc5028ba00225ea720cf0f287e934dc2bd5/uv-0.8.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:069eed78b79d1e88bced23e3d4303348edb0a0209e7cae0f20024c42430bf50f", size = 17882409, upload-time = "2025-09-03T14:31:36.993Z" },
-    { url = "https://files.pythonhosted.org/packages/25/21/57df6d53fbadfa947d9d65a0926e5d8540199f49aa958d23be2707262a80/uv-0.8.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:333a93bb6af64f3b95ee99e82b4ea227e2af6362c45f91c89a24e2bfefb628f9", size = 19557216, upload-time = "2025-09-03T14:31:39.245Z" },
-    { url = "https://files.pythonhosted.org/packages/68/22/c3784749e1c78119e5375ec34c6ea29e944192a601f17c746339611db237/uv-0.8.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7d5b19ac2bdda3d1456b5d6013af50b443ffb0e40c66d42874f71190a5364711", size = 19781097, upload-time = "2025-09-03T14:31:42.314Z" },
-    { url = "https://files.pythonhosted.org/packages/00/28/0597599fb35408dd73e0a7d25108dca1fa6ce8f8d570c8f24151b0016eef/uv-0.8.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3330bb4f206a6180679a75a8b2e77ff0f933fcb06c028b6f4da877b10a5e4f95", size = 20741549, upload-time = "2025-09-03T14:31:44.574Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/61/98fa07981722660f5a3c28b987df99c2486f63d01b1256e6cca05a43bdce/uv-0.8.15-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:de9896ad4fa724ab317a8048f4891b9b23df1403b3724e96606f3be2dbbbf009", size = 22193727, upload-time = "2025-09-03T14:31:46.915Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/65/523188e11a759144b00f0fe48943f6d00706fcd9b5f561a54a07b9fd4541/uv-0.8.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:226360003e71084e0a73cbec72170e88634b045e95529654d067ea3741bba242", size = 21817550, upload-time = "2025-09-03T14:31:49.548Z" },
-    { url = "https://files.pythonhosted.org/packages/99/3c/7898acf3d9ed2d3a2986cccc8209c14d3e9ac72dfaa616e49d329423b1d3/uv-0.8.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9488260536b35b94a79962fea76837f279c0cd0ae5021c761e66b311f47ffa70", size = 21024011, upload-time = "2025-09-03T14:31:51.789Z" },
-    { url = "https://files.pythonhosted.org/packages/13/fc/e0da45ee179367dcc1e1040ad00ed8a99b78355d43024b0b5fc2edf5c389/uv-0.8.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07765f99fd5fd3b257d7e210e8d0844c0a8fd111612e31fcca66a85656cc728e", size = 21009338, upload-time = "2025-09-03T14:31:54.104Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/5d/180904fa7ed49081b27f00e86f7220ca62cc098d7ef6459f0c69a8ae8f74/uv-0.8.15-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:c4868e6a4e1a8c777a5ba3cff452c405837318fb0b272ff203bfda0e1b8fc54d", size = 19799578, upload-time = "2025-09-03T14:31:56.47Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/09/fed823212e695b6765bdb8462850abffbe685cd965c4de905efed5e2e5c9/uv-0.8.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:3ec78a54a8eb0bbb9a9c653982390af84673657c8a48a0be6cdcb81d7d3e95c3", size = 20845428, upload-time = "2025-09-03T14:31:59.475Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/f3/9c4211897c00f79b7973a10800166e0580eaad20fe27f7c06adb7b248ac7/uv-0.8.15-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:a022a752d20da80d2a49fc0721522a81e3a32efe539152d756d84ebdba29dbc3", size = 19728113, upload-time = "2025-09-03T14:32:01.686Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/43/4ec6047150e2fba494d80d36b881a1a973835afa497ae9ccdf51828cae4f/uv-0.8.15-py3-none-musllinux_1_1_i686.whl", hash = "sha256:3780d2f3951d83e55812fdeb7eee233787b70c774497dbfc55b0fdf6063aa345", size = 20169115, upload-time = "2025-09-03T14:32:03.995Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/98/b4220bf462fb225c4a2d74ef4f105020238472b4b0da94ebc17a310d7b4e/uv-0.8.15-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:56f2451c9193ee1754ce1d8390ded68e9cb8dee0aaf7e2f38a9bd04d99be1be7", size = 21129804, upload-time = "2025-09-03T14:32:06.204Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/b8/40ce3d385254ac87a664a5d9a4664fac697e2734352f404382b81d03235b/uv-0.8.15-py3-none-win32.whl", hash = "sha256:89c7c10089e07d944c72d388fd88666c650dec2f8c79ca541e365f32843882c6", size = 19077103, upload-time = "2025-09-03T14:32:08.628Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/9d/081a0af395c0e307c0c930e80161a2aa551c25064cfb636d060574566fa4/uv-0.8.15-py3-none-win_amd64.whl", hash = "sha256:6aa824ab933dfafe11efe32e6541c6bcd65ecaa927e8e834ea6b14d3821020f6", size = 21179816, upload-time = "2025-09-03T14:32:11.42Z" },
-    { url = "https://files.pythonhosted.org/packages/30/47/d8f50264a8c8ebbb9a44a8fed08b6e873d943adf299d944fe3a776ff5fbf/uv-0.8.15-py3-none-win_arm64.whl", hash = "sha256:a395fa1fc8948eacdd18e4592ed489fad13558b13fea6b3544cb16e5006c5b02", size = 19448833, upload-time = "2025-09-03T14:32:13.639Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
closes #11 

This PR takes us from errors like: 
```
❯ hog run missing_dependency.py
/Users/owen/Repositories/groundhog/.venv/lib/python3.13/site-packages/globus_compute_sdk/sdk/client.py:299: UserWarning:
Environment differences detected between local SDK and endpoint 8ee0c1cf-55b2-b520-46e2-1ad3d413f93f workers:
	    SDK: Python 3.13.1/Dill 0.3.9
	Workers: Python 3.12.11/Dill 0.3.9
This may cause serialization issues.  See https://globus-compute.readthedocs.io/en/latest/sdk/executor_user_guide.html#avoiding-serialization-errors for more information.
  warnings.warn(check_result, UserWarning)
exit code: 1
   stdout:


   stderr:
[... truncated; see .stderr for full output ...]
    results = hello_pandas(*args, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/x-oprice/.cache/uv/environments-v2/groundhog-f0083bf3-06786d64955705bc/lib/python3.12/site-packages/groundhog_hpc/function.py", line 25, in __call__
    return self._local_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/x-oprice/.globus_compute/uep.5aafb4c1-27b2-40d8-a038-a0277611868f.8ee0c1cf-55b2-b520-46e2-1ad3d413f93f/tasks_working_dir/./groundhog-f0083bf3.py", line 19, in hello_pandas
    import pandas
ModuleNotFoundError: No module named 'pandas'
cat: ./groundhog-f0083bf3.out: No such file or directory
WARNING: Task sandboxing will not work due to endpoint misconfiguration. Please enable sandboxing on the remote endpoint.

exception: subprocess.CalledProcessError
None
exit code: 1
   stdout:


   stderr:
[... truncated; see .stderr for full output ...]
    results = hello_pandas(*args, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/x-oprice/.cache/uv/environments-v2/groundhog-f0083bf3-06786d64955705bc/lib/python3.12/site-packages/groundhog_hpc/function.py", line 25, in __call__
    return self._local_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/x-oprice/.globus_compute/uep.5aafb4c1-27b2-40d8-a038-a0277611868f.8ee0c1cf-55b2-b520-46e2-1ad3d413f93f/tasks_working_dir/./groundhog-f0083bf3.py", line 19, in hello_pandas
    import pandas
ModuleNotFoundError: No module named 'pandas'
cat: ./groundhog-f0083bf3.out: No such file or directory
WARNING: Task sandboxing will not work due to endpoint misconfiguration. Please enable sandboxing on the remote endpoint.

exception: subprocess.CalledProcessError


```
to cleaner errors like 
```
❯ hog run missing_dependency.py
Remote execution failed (exit code 1):
Traceback (most recent call last):
  File "/home/x-oprice/.globus_compute/uep.5aafb4c1-27b2-40d8-a038-a0277611868f.8ee0c1cf-55b2-b520-46e2-1ad3d413f93f/tasks_working_dir/groundhog-768b9986.py", line 38, in <module>
    results = hello_pandas(*args, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/x-oprice/.cache/uv/environments-v2/groundhog-768b9986-7940eae0b83298ec/lib/python3.12/site-packages/groundhog_hpc/function.py", line 25, in __call__
    return self._local_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/x-oprice/.globus_compute/uep.5aafb4c1-27b2-40d8-a038-a0277611868f.8ee0c1cf-55b2-b520-46e2-1ad3d413f93f/tasks_working_dir/groundhog-768b9986.py", line 19, in hello_pandas
    import pandas
ModuleNotFoundError: No module named 'pandas'
```

I also triggered a few other kinds of errors (especially ones that occurred before the worker actually starts) that previously required me to SSH into anvil to read, but now are printed cleanly to my terminal: 
```
❯ hog run incompatible_dependency.py
Error:
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 Traceback (most recent call last):
   File "/apps/anvil/external/globus/2025.09.26/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
     raise self._exception
 parsl.executors.errors.BadStateException: Executor GlobusComputeEngine-HighThroughputExecutor failed due to: Error 1:
 	Failed to start block 0: Cannot launch job parsl.GlobusComputeEngine-HighThroughputExecutor.block-0.1759171197.108797: Could not read job ID from submit command standard output; recode=1, stdout=, stderr=sbatch: error: Batch job submission failed: Invalid qos specification

 Error 2:
 	Failed to start block 1: Cannot launch job parsl.GlobusComputeEngine-HighThroughputExecutor.block-1.1759171197.2939727: Could not read job ID from submit command standard output; recode=1, stdout=, stderr=sbatch: error: Batch job submission failed: Invalid qos specification


 --------------------------------------------------------------------

~/Repositories/groundhog/scripts owen/better-error-messages* 17s
.venv ❯ hog run incompatible_dependency.py
Remote execution failed (exit code 1):
Downloading cpython-3.9.23-linux-x86_64-gnu (download) (25.9MiB)
 Downloading cpython-3.9.23-linux-x86_64-gnu (download)
  × No solution found when resolving script dependencies:
  ╰─▶ Because the current Python version (3.9.23) does not satisfy
      Python>=3.11 and groundhog-hpc==0.1.0 depends on Python>=3.11, we can
      conclude that groundhog-hpc==0.1.0 cannot be used.
      And because only groundhog-hpc==0.1.0 is available and you require
      groundhog-hpc, we can conclude that your requirements are unsatisfiable.

~/Repositories/groundhog/scripts owen/better-error-messages* 6s
.venv ❯ hog run incompatible_dependency.py
Remote execution failed (exit code 2):
error: No interpreter found for Python ==3.11 in virtual environments or managed installations
```