### PR TITLE
improved serialization

### DIFF
--- a/examples/hello_dependencies.py
+++ b/examples/hello_dependencies.py
@@ -1,0 +1,52 @@
+# /// script
+# requires-python = "==3.12.*"
+# dependencies = [
+#     "torch",
+# ]
+#
+# ///
+"""
+sample script for `hog run` to execute on the remote globus compute endpoint with uv
+"""
+
+import json
+import os
+
+import groundhog_hpc as hog
+
+
+@hog.function(walltime=30, account="cis250223")
+def hello_environment():
+    return dict(os.environ)
+
+
+@hog.function(walltime=30, account="cis250223")
+def hello_torch():
+    import torch
+
+    msg = f"Hello, cuda? {torch.cuda.is_available()=}"
+    return msg
+
+
+@hog.function(walltime=30, account="cis250223")
+def hello_hog():
+    return f"{hog.__version__=}"
+
+
+@hog.harness()
+def test_env():
+    print("running locally...")
+    local_env = hello_environment()
+    print(json.dumps(local_env, indent=2))
+
+    print("running remotely...")
+    remote_env = hello_environment.remote()
+    print(json.dumps(remote_env, indent=2))
+
+    return remote_env
+
+
+@hog.harness()
+def test_deps():
+    print(hello_torch.remote())
+    print(hello_hog.remote())

--- a/examples/hello_serialization.py
+++ b/examples/hello_serialization.py
@@ -1,0 +1,70 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+#
+# ///
+"""
+This one shows off argument / serialization handling, including a simple custom class
+"""
+
+from dataclasses import dataclass
+
+import groundhog_hpc as hog
+
+GARDEN_ACCT = "cis250461"
+DIAMOND_ACCT = "cis250223"
+
+
+@dataclass
+class Person:
+    name: str
+    age: int
+    hobbies: list[str]
+
+
+@hog.function(account=DIAMOND_ACCT)
+def hello_arguments_json(data: dict, multiplier: int):
+    """Simple function that accepts and returns JSON-serializable types."""
+    result = {k: v * multiplier for k, v in data.items()}
+    return result
+
+
+@hog.function(account=DIAMOND_ACCT)
+def hello_arguments_pkl(obj):
+    """Function that accepts and returns non-JSON-serializable types (sets, custom classes)."""
+    # Demonstrate working with a set (not JSON-serializable)
+    if isinstance(obj, set):
+        return {f"processed_{item}" for item in obj}
+    # Return the object type name as a set
+    return {type(obj).__name__, "processed"}
+
+
+@hog.function(account=DIAMOND_ACCT)
+def hello_dataclass(person: Person):
+    """Function that accepts and returns a custom dataclass."""
+    # Modify the person and return a new instance
+    return Person(
+        name=person.name.upper(),
+        age=person.age + 1,
+        hobbies=person.hobbies + ["groundhog testing"],
+    )
+
+
+@hog.harness()
+def main():
+    # Test JSON-serializable types
+    json_arg = {"a": 1, "b": 2, "c": 3}
+    json_result = hello_arguments_json.remote(json_arg, 10)
+    print(f"JSON test: {json_arg} -> {json_result}")
+
+    # Test non-JSON-serializable types (set)
+    pickle_arg = {"apple", "banana", "cherry"}
+    pickle_result = hello_arguments_pkl.remote(pickle_arg)
+    print(f"Pickle test: {pickle_arg} -> {pickle_result}")
+
+    # Test custom dataclass
+    dataclass_arg = Person(name="Alice", age=30, hobbies=["reading", "hiking"])
+    dataclass_result = hello_dataclass.remote(dataclass_arg)
+    print(f"Dataclass test: {dataclass_arg} -> {dataclass_result}")
+
+    return json_result, pickle_result, dataclass_result

--- a/examples/hello_slots.py
+++ b/examples/hello_slots.py
@@ -1,0 +1,90 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+#
+# ///
+"""
+Test script to demonstrate tricky serialization/custom types, run locally with
+3.10 and remotely with 3.11+. (Python 3.11 changed how __slots__ are handled in
+dataclasses etc)
+"""
+
+from dataclasses import dataclass
+
+import groundhog_hpc as hog
+
+DIAMOND_ACCT = "cis250223"
+
+
+class Person:
+    __slots__ = ("name", "age")
+
+    def __init__(self, name, age):
+        self.name = name
+        self.age = age
+
+    def __getstate__(self):
+        # Custom getstate that returns a dict
+        return {"name": self.name, "age": self.age, "version": 1}
+
+    def __setstate__(self, state):
+        self.name = state["name"]
+        self.age = state["age"]
+
+
+@dataclass(slots=True)
+class BaseEntity:
+    """Base class with __slots__."""
+
+    id: str
+
+
+@dataclass(slots=True)
+class SlottedPerson(BaseEntity):
+    """Derived dataclass with __slots__ that inherits from slotted base.
+
+    In Python 3.11+, if 'id' were redeclared here, it would NOT be included
+    in the generated __slots__ to prevent overriding the base class slot.
+    """
+
+    name: str
+    age: int
+    city: str
+
+
+@hog.function(account=DIAMOND_ACCT)
+def process_stateful_person(person: Person) -> Person:
+    """Function that accepts and returns a slotted class with custom get/set state."""
+    return Person(
+        name=person.name.upper(),
+        age=person.age + 1,
+    )
+
+
+@hog.function(account=DIAMOND_ACCT)
+def process_slotted_person(person: SlottedPerson) -> SlottedPerson:
+    """Function that accepts and returns a slotted dataclass with inheritance."""
+    return SlottedPerson(
+        id=person.id,
+        name=person.name.upper(),
+        age=person.age + 1,
+        city=f"{person.city} (processed)",
+    )
+
+
+@hog.harness()
+def main():
+    # Create a slotted dataclass instance with inheritance
+    person = SlottedPerson(id="person-123", name="Bob", age=25, city="Vegas, baby 🎰")
+    print(f"Sending: {person}")
+
+    # This should fail due to pickle/slots incompatibility across Python versions
+    result = process_slotted_person.remote(person)
+    print(f"Received: {result}")
+
+    person2 = Person(name="boB", age=52)
+    print(f"Sending: {person2}")
+    result2 = process_stateful_person.remote(person2)
+    print(f"Received: {result2}")
+
+    return result, result2

--- a/src/groundhog_hpc/serialization.py
+++ b/src/groundhog_hpc/serialization.py
@@ -1,10 +1,34 @@
+import base64
 import json
+import pickle
 from typing import Any
 
 
 def serialize(obj: Any) -> str:
-    return json.dumps(obj)
+    """Serialize an object to a string.
+
+    First attempts JSON serialization for efficiency and human-readability.
+    Falls back to pickle + base64 encoding for non-JSON-serializable types.
+    """
+    try:
+        return json.dumps(obj)
+    except (TypeError, ValueError):
+        # Fall back to pickle for non-JSON-serializable types
+        pickled = pickle.dumps(obj)
+        b64_encoded = base64.b64encode(pickled).decode("ascii")
+        # Prefix with marker to indicate pickle encoding
+        return f"__PICKLE__:{b64_encoded}"
 
 
 def deserialize(payload: str) -> Any:
-    return json.loads(payload)
+    """Deserialize a string to an object.
+
+    Automatically detects whether the payload is JSON or pickle+base64 encoded.
+    """
+    if payload.startswith("__PICKLE__:"):
+        # Extract base64 encoded pickle data
+        b64_data = payload[len("__PICKLE__:") :]
+        pickled = base64.b64decode(b64_data.encode("ascii"))
+        return pickle.loads(pickled)
+    else:
+        return json.loads(payload)


### PR DESCRIPTION
closes #18 

First pass at supporting serialization of trickier python objects. This just uses vanilla `pickle`, so it doesn't include things like nested functions etc that `cloudpickle`/`dill` would be able to handle, but it turned out to be surprisingly robust to my first few attempts at breaking it (including across versions). I included the manual test scripts in `examples/` 

since JSON is almost certainly preferable to a b64-encoded pickle dump, I had the `serialize`/`deserialize` functions try treating it as json first before falling back to pickle. 

I also needed to tweak `hog run` so that when it `exec`s user code it does so in the `__main__` namespace, because the otherwise it wouldn't serialize a custom class with e.g. `Error: Can't pickle <class 'Person'>: attribute lookup Person on builtins failed.`

