### PR TITLE
isolate local serialization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,10 @@ requires-python = ">=3.10"
 dynamic = ["version"] # read from git tag
 dependencies = [
     "globus-compute-sdk>=3.12.0",
+    "packaging>=24.0",
+    "tomli>=1.1.0 ; python_full_version < '3.11'",
     "typer>=0.16.1",
+    "uv>=0.8.22",
 ]
 
 [project.scripts]

--- a/src/groundhog_hpc/app/main.py
+++ b/src/groundhog_hpc/app/main.py
@@ -12,6 +12,7 @@ import groundhog_hpc
 from groundhog_hpc.environment import read_pep723
 from groundhog_hpc.errors import RemoteExecutionError
 from groundhog_hpc.harness import Harness
+from groundhog_hpc.utils import get_groundhog_version_spec
 
 app = typer.Typer()
 
@@ -59,7 +60,7 @@ def run(
                     "uv",
                     "run",
                     "--with",
-                    f"groundhog-hpc=={groundhog_hpc.__version__}",
+                    get_groundhog_version_spec(),
                     "--python",
                     requires_python,
                     "hog",

--- a/src/groundhog_hpc/app/main.py
+++ b/src/groundhog_hpc/app/main.py
@@ -7,6 +7,7 @@ from typing import Optional
 import typer
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
+from uv import find_uv_bin
 
 import groundhog_hpc
 from groundhog_hpc.environment import read_pep723
@@ -15,11 +16,6 @@ from groundhog_hpc.harness import Harness
 from groundhog_hpc.utils import get_groundhog_version_spec
 
 app = typer.Typer()
-
-
-def _python_version_matches(current: str, spec: str) -> bool:
-    """Check if current Python version satisfies the PEP 440 version specifier."""
-    return Version(current) in SpecifierSet(spec)
 
 
 @app.command(no_args_is_help=True)
@@ -93,13 +89,19 @@ def run(
         raise typer.Exit(1)
 
 
+def _python_version_matches(current: str, spec: str) -> bool:
+    """Check if current Python version satisfies the PEP 440 version specifier."""
+    return Version(current) in SpecifierSet(spec)
+
+
 def _re_run_with_version(
     requires_python: str, groundhog_spec: str, script_path: str, harness: str
 ) -> subprocess.CompletedProcess:
     # Re-exec with uv run in isolated environment
     cmd = [
-        "uv",
+        f"{find_uv_bin()}",
         "run",
+        "-qq",
         "--with",
         groundhog_spec,
         "--python",

--- a/src/groundhog_hpc/environment.py
+++ b/src/groundhog_hpc/environment.py
@@ -1,0 +1,32 @@
+import re
+import sys
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomlli as tomllib
+
+# see: https://peps.python.org/pep-0723/#reference-implementation
+INLINE_METADATA_REGEX = (
+    r"(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$"
+)
+
+
+def read_pep723(script: str) -> dict | None:
+    name = "script"
+    matches = list(
+        filter(
+            lambda m: m.group("type") == name,
+            re.finditer(INLINE_METADATA_REGEX, script),
+        )
+    )
+    if len(matches) > 1:
+        raise ValueError(f"Multiple {name} blocks found")
+    elif len(matches) == 1:
+        content = "".join(
+            line[2:] if line.startswith("# ") else line[1:]
+            for line in matches[0].group("content").splitlines(keepends=True)
+        )
+        return tomllib.loads(content)
+    else:
+        return None

--- a/src/groundhog_hpc/environment.py
+++ b/src/groundhog_hpc/environment.py
@@ -4,7 +4,7 @@ import sys
 if sys.version_info >= (3, 11):
     import tomllib
 else:
-    import tomlli as tomllib
+    import tomli as tomllib
 
 # see: https://peps.python.org/pep-0723/#reference-implementation
 INLINE_METADATA_REGEX = (

--- a/src/groundhog_hpc/harness.py
+++ b/src/groundhog_hpc/harness.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 from typing import Callable
 
@@ -6,6 +7,7 @@ class Harness:
     def __init__(self, func: Callable):
         self.func = func
         self.name = func.__qualname__
+        self._validate_signature()
 
     def __call__(self):
         if not self._invoked_by_cli():
@@ -27,3 +29,11 @@ class Harness:
 
     def _invoked_by_cli(self):
         return bool(os.environ.get(f"GROUNDHOG_RUN_{self.name}".upper()))
+
+    def _validate_signature(self):
+        sig = inspect.signature(self.func)
+        if len(sig.parameters) > 0:
+            raise TypeError(
+                f"Harness function '{self.name}' must not accept any arguments, "
+                f"but has parameters: {list(sig.parameters.keys())}"
+            )

--- a/src/groundhog_hpc/runner.py
+++ b/src/groundhog_hpc/runner.py
@@ -4,10 +4,10 @@ from pathlib import Path
 from typing import Callable
 from uuid import UUID
 
-import groundhog_hpc
 from groundhog_hpc.errors import RemoteExecutionError
 from groundhog_hpc.serialization import deserialize, serialize
 from groundhog_hpc.settings import DEFAULT_USER_CONFIG
+from groundhog_hpc.utils import get_groundhog_version_spec
 
 warnings.filterwarnings(
     "ignore",
@@ -57,7 +57,7 @@ def script_to_callable(
         user_script, function_name, script_hash, script_basename
     )
 
-    version_spec = _get_version_spec()
+    version_spec = get_groundhog_version_spec()
 
     def run(*args, **kwargs):
         shell_fn = gc.ShellFunction(cmd=SHELL_COMMAND_TEMPLATE, walltime=walltime)
@@ -94,18 +94,6 @@ def _script_hash_prefix(contents: str, length=8) -> str:
 
 def _extract_script_basename(script_path: str) -> str:
     return Path(script_path).stem
-
-
-def _get_version_spec() -> str:
-    # Ensure matching version is installed on endpoint
-    if "dev" not in groundhog_hpc.__version__:
-        version_spec = f"groundhog-hpc=={groundhog_hpc.__version__}"
-    else:
-        # Get commit hash from e.g. "0.0.0.post11.dev0+71128ec"
-        commit_hash = groundhog_hpc.__version__.split("+")[-1]
-        version_spec = f"groundhog-hpc@git+https://github.com/Garden-AI/groundhog.git@{commit_hash}"
-
-    return version_spec
 
 
 def _inject_script_boilerplate(

--- a/src/groundhog_hpc/utils.py
+++ b/src/groundhog_hpc/utils.py
@@ -1,0 +1,17 @@
+import groundhog_hpc
+
+
+def get_groundhog_version_spec() -> str:
+    """Return the current package version spec.
+
+    Used for consistent installation across local/remote environments, e.g.:
+        `uv run --with {get_groundhog_version_spec()}`
+    """
+    if "dev" not in groundhog_hpc.__version__:
+        version_spec = f"groundhog-hpc=={groundhog_hpc.__version__}"
+    else:
+        # Get commit hash from e.g. "0.0.0.post11.dev0+71128ec"
+        commit_hash = groundhog_hpc.__version__.split("+")[-1]
+        version_spec = f"groundhog-hpc@git+https://github.com/Garden-AI/groundhog.git@{commit_hash}"
+
+    return version_spec

--- a/uv.lock
+++ b/uv.lock
@@ -332,7 +332,10 @@ name = "groundhog-hpc"
 source = { editable = "." }
 dependencies = [
     { name = "globus-compute-sdk" },
+    { name = "packaging" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typer" },
+    { name = "uv" },
 ]
 
 [package.dev-dependencies]
@@ -345,7 +348,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "globus-compute-sdk", specifier = ">=3.12.0" },
+    { name = "packaging", specifier = ">=24.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.1.0" },
     { name = "typer", specifier = ">=0.16.1" },
+    { name = "uv", specifier = ">=0.8.22" },
 ]
 
 [package.metadata.requires-dev]
@@ -837,6 +843,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "uv"
+version = "0.8.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/39/231e123458d50dd497cf6d27b592f5d3bc3e2e50f496b56859865a7b22e3/uv-0.8.22.tar.gz", hash = "sha256:e6e1289c411d43e0ca245f46e76457f3807de646d90b656591b6cf46348bed5c", size = 3667007, upload-time = "2025-09-23T20:35:14.736Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/e6/bb440171dd8a36d0f9874b4c71778f7bbc83e62ccf42c62bd1583c802793/uv-0.8.22-py3-none-linux_armv6l.whl", hash = "sha256:7350c5f82d9c38944e6466933edcf96a90e0cb85eae5c0e53a5bc716d6f62332", size = 20554993, upload-time = "2025-09-23T20:34:26.549Z" },
+    { url = "https://files.pythonhosted.org/packages/28/e9/813f7eb9fb9694c4024362782c8933e37887b5195e189f80dc40f2da5958/uv-0.8.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:89944e99b04cc8542cb5931306f1c593f00c9d6f2b652fffc4d84d12b915f911", size = 19565276, upload-time = "2025-09-23T20:34:30.436Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/bf37d86af6e16e45fa2b1a03300784ff3297aa9252a23dfbeaf6e391e72e/uv-0.8.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6706b782ad75662df794e186d16b9ffa4946d57c88f21d0eadfd43425794d1b0", size = 18162303, upload-time = "2025-09-23T20:34:32.761Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/eb/289b6a59fff1613958499a886283f52403c5ce4f0a8a550b86fbd70e8e4f/uv-0.8.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:d6a33bd5309f8fb77d9fc249bb17f77a23426e6153e43b03ca1cd6640f0a423d", size = 19982769, upload-time = "2025-09-23T20:34:34.962Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ba/2fcc3ce75be62eecf280f3cbe74d186f371a468fad3167b5a34dee2f904e/uv-0.8.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4a982bdd5d239dd6dd2b4219165e209c75af1e1819730454ee46d65b3ccf77a3", size = 20163849, upload-time = "2025-09-23T20:34:37.744Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/4d/4fc9a508c2c497a80c41710c96f1782a29edecffcac742f3843af061ba8f/uv-0.8.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:58b6fb191a04b922dc3c8fea6660f58545a651843d7d0efa9ae69164fca9e05d", size = 21130147, upload-time = "2025-09-23T20:34:40.414Z" },
+    { url = "https://files.pythonhosted.org/packages/71/79/6bcb3c3c3b7c9cb1a162a76dca2b166752e4ba39ec90e802b252f0a54039/uv-0.8.22-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:8ea724ae9f15c0cb4964e9e2e1b21df65c56ae02a54dc1d8a6ea44a52d819268", size = 22561974, upload-time = "2025-09-23T20:34:42.843Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/98/89bb29d82ff7e5ab1b5e862d9bdc12b1d3a4d5201cf558432487e29cc448/uv-0.8.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7378127cbd6ebce8ba6d9bdb88aa8ea995b579824abb5ec381c63b3a123a43be", size = 22183189, upload-time = "2025-09-23T20:34:45.57Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b0/354c7d7d11fff2ee97bb208f0fec6b09ae885c0d591b6eff2d7b84cc6695/uv-0.8.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7e761ca7df8a0059b3fae6bc2c1db24583fa00b016e35bd22a5599d7084471a7", size = 21492888, upload-time = "2025-09-23T20:34:48.45Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a9/a83cee9b8cf63e57ce64ba27c77777cc66410e144fd178368f55af1fa18d/uv-0.8.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8efec4ef5acddc35f0867998c44e0b15fc4dace1e4c26d01443871a2fbb04bf6", size = 21252972, upload-time = "2025-09-23T20:34:50.862Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/0c/71d5d5d3fca7aa788d63297a06ca26d3585270342277b52312bb693b100c/uv-0.8.22-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:9eb3b4abfa25e07d7e1bb4c9bb8dbbdd51878356a37c3c4a2ece3d68d4286f28", size = 20115520, upload-time = "2025-09-23T20:34:53.165Z" },
+    { url = "https://files.pythonhosted.org/packages/da/90/57fae2798be1e71692872b8304e2e2c345eacbe2070bdcbba6d5a7675fa1/uv-0.8.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b1fdffc2e71892ce648b66317e478fe8884d0007e20cfa582fff3dcea588a450", size = 21168787, upload-time = "2025-09-23T20:34:55.638Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f6/23c8d8fdd1084603795f6344eee8e763ba06f891e863397fe5b7b532cb58/uv-0.8.22-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:f6ded9bacb31441d788afca397b8b884ebc2e70f903bea0a38806194be4b249c", size = 20170112, upload-time = "2025-09-23T20:34:58.008Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/801d517964a7200014897522ae067bf7111fc2e138b38d13d9df9544bf06/uv-0.8.22-py3-none-musllinux_1_1_i686.whl", hash = "sha256:aefa0cb27a86d2145ca9290a1e99c16a17ea26a4f14a89fb7336bc19388427cc", size = 20537608, upload-time = "2025-09-23T20:35:00.44Z" },
+    { url = "https://files.pythonhosted.org/packages/20/8a/1bd4159089f8df0128e4ceb7f4c31c23a451984a5b49c13489c70e721335/uv-0.8.22-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:9757f0b0c7d296f1e354db442ed0ce39721c06d11635ce4ee6638c5e809a9cb4", size = 21471224, upload-time = "2025-09-23T20:35:03.718Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ba/262d16059e3b0837728e8aa3590fc2c7bc23e0cefec81d6903b4b6af080a/uv-0.8.22-py3-none-win32.whl", hash = "sha256:36c7aecdb0044caf15ace00da00af172759c49c832f0017b7433d80f46552cd3", size = 19350586, upload-time = "2025-09-23T20:35:06.837Z" },
+    { url = "https://files.pythonhosted.org/packages/38/82/94f08992eeb193dc3d5baac437d1867cd37f040f34c7b1a4b1bde2bc4b4b/uv-0.8.22-py3-none-win_amd64.whl", hash = "sha256:cda349c9ea53644d8d9ceae30db71616b733eb5330375ab4259765aef494b74e", size = 21355960, upload-time = "2025-09-23T20:35:09.472Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/00/2c7a93bbe93b74dc0496a8e875bac11027cb30c29636c106c6e49038b95f/uv-0.8.22-py3-none-win_arm64.whl", hash = "sha256:2a436b941b6e79fe1e1065b705a5689d72210f4367cbe885e19910cbcde2e4a1", size = 19778983, upload-time = "2025-09-23T20:35:12.188Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
closes #26 (bonus: closes #13)

This adds a few lightweight dependencies in order to parse the script metadata ourselves and ensure uv is present locally before we re-run the command in a fresh environment. 

Also created a handful of new modules -- `utils.py` with the common logic for installing groundhog-hpc programmatically (per `groundhog_hpc.__version__`) and `environment.py` with logic for extracting dependency / python information. Eventually, I'm thinking that's where the `Image`-like abstraction should live. 

