### PR TITLE
size limit errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,20 @@ ignore = ["E501"]  # line length handled by pre-commit hook
 
 [tool.ty.src]
 exclude = ["examples", "scripts", "tests"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["src"]
+omit = ["*/tests/*", "*/test_*.py"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+]

--- a/src/groundhog_hpc/errors.py
+++ b/src/groundhog_hpc/errors.py
@@ -32,6 +32,6 @@ class PayloadTooLargeError(Exception):
     def __init__(self, size_mb: float):
         self.size_mb = size_mb
         super().__init__(
-            f"Payload size ({size_mb:.2f} MB) exceeds Globus Compute's 10MB limit. "
+            f"Payload size ({size_mb:.2f} MB) exceeds Globus Compute's 10 MB limit. "
             "See also: https://globus-compute.readthedocs.io/en/latest/limits.html#data-limits"
         )

--- a/src/groundhog_hpc/errors.py
+++ b/src/groundhog_hpc/errors.py
@@ -29,10 +29,9 @@ class PayloadTooLargeError(Exception):
         limit_mb: The size limit in megabytes (default: 10)
     """
 
-    def __init__(self, size_mb: float, limit_mb: int = 10):
+    def __init__(self, size_mb: float):
         self.size_mb = size_mb
-        self.limit_mb = limit_mb
         super().__init__(
-            f"Payload size ({size_mb:.2f} MB) exceeds Globus Compute's {limit_mb} MB limit. "
+            f"Payload size ({size_mb:.2f} MB) exceeds Globus Compute's 10MB limit. "
             "See also: https://globus-compute.readthedocs.io/en/latest/limits.html#data-limits"
         )

--- a/src/groundhog_hpc/errors.py
+++ b/src/groundhog_hpc/errors.py
@@ -19,3 +19,20 @@ class RemoteExecutionError(Exception):
         self.stderr = "\n".join(lines)
         self.returncode = returncode
         super().__init__(message)
+
+
+class PayloadTooLargeError(Exception):
+    """Raised when a serialized payload exceeds Globus Compute's 10MB size limit.
+
+    Attributes:
+        size_mb: The size of the payload in megabytes
+        limit_mb: The size limit in megabytes (default: 10)
+    """
+
+    def __init__(self, size_mb: float, limit_mb: int = 10):
+        self.size_mb = size_mb
+        self.limit_mb = limit_mb
+        super().__init__(
+            f"Payload size ({size_mb:.2f} MB) exceeds Globus Compute's {limit_mb} MB limit. "
+            "Consider reducing the amount of data being passed or returned."
+        )

--- a/src/groundhog_hpc/errors.py
+++ b/src/groundhog_hpc/errors.py
@@ -34,5 +34,5 @@ class PayloadTooLargeError(Exception):
         self.limit_mb = limit_mb
         super().__init__(
             f"Payload size ({size_mb:.2f} MB) exceeds Globus Compute's {limit_mb} MB limit. "
-            "Consider reducing the amount of data being passed or returned."
+            "See also: https://globus-compute.readthedocs.io/en/latest/limits.html#data-limits"
         )

--- a/src/groundhog_hpc/serialization.py
+++ b/src/groundhog_hpc/serialization.py
@@ -3,21 +3,37 @@ import json
 import pickle
 from typing import Any
 
+from groundhog_hpc.errors import PayloadTooLargeError
+
+# Globus Compute's payload size limit in bytes (10 MB)
+PAYLOAD_SIZE_LIMIT_BYTES = 10 * 1024 * 1024
+
 
 def serialize(obj: Any) -> str:
     """Serialize an object to a string.
 
     First attempts JSON serialization for efficiency and human-readability.
     Falls back to pickle + base64 encoding for non-JSON-serializable types.
+
+    Raises:
+        PayloadTooLargeError: If the serialized payload exceeds 10 MB.
     """
     try:
-        return json.dumps(obj)
+        result = json.dumps(obj)
     except (TypeError, ValueError):
         # Fall back to pickle for non-JSON-serializable types
         pickled = pickle.dumps(obj)
         b64_encoded = base64.b64encode(pickled).decode("ascii")
         # Prefix with marker to indicate pickle encoding
-        return f"__PICKLE__:{b64_encoded}"
+        result = f"__PICKLE__:{b64_encoded}"
+
+    # Check payload size
+    payload_size = len(result.encode("utf-8"))
+    if payload_size > PAYLOAD_SIZE_LIMIT_BYTES:
+        size_mb = payload_size / (1024 * 1024)
+        raise PayloadTooLargeError(size_mb)
+
+    return result
 
 
 def deserialize(payload: str) -> Any:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -13,21 +13,21 @@ class TestInjectScriptBoilerplate:
     def test_adds_main_block(self, sample_pep723_script):
         """Test that __main__ block is added."""
         injected = _inject_script_boilerplate(
-            sample_pep723_script, "add", "abc123", "test"
+            sample_pep723_script, "add", "test-abc123"
         )
         assert 'if __name__ == "__main__":' in injected
 
     def test_calls_target_function(self, sample_pep723_script):
         """Test that the target function is called with deserialized args."""
         injected = _inject_script_boilerplate(
-            sample_pep723_script, "multiply", "abc123", "test"
+            sample_pep723_script, "multiply", "test-abc123"
         )
         assert "results = multiply(*args, **kwargs)" in injected
 
     def test_preserves_original_script(self, sample_pep723_script):
         """Test that the original script content is preserved."""
         injected = _inject_script_boilerplate(
-            sample_pep723_script, "add", "abc123", "test"
+            sample_pep723_script, "add", "test-abc123"
         )
         # Original decorators and functions should still be there
         assert sample_pep723_script in injected
@@ -47,13 +47,13 @@ if __name__ == "__main__":
         with pytest.raises(
             AssertionError, match="can't define custom `__main__` logic"
         ):
-            _inject_script_boilerplate(script_with_main, "foo", "abc123", "test")
+            _inject_script_boilerplate(script_with_main, "foo", "test-abc123")
 
     def test_uses_correct_file_paths(self):
-        """Test that file paths use script_basename and script_hash."""
+        """Test that file paths use script_name (basename-hash format)."""
         script = (
             "import groundhog_hpc as hog\n\n@hog.function()\ndef test():\n    return 1"
         )
-        injected = _inject_script_boilerplate(script, "test", "deadbeef", "my_script")
-        assert "my_script-deadbeef.in" in injected
-        assert "my_script-deadbeef.out" in injected
+        injected = _inject_script_boilerplate(script, "test", "my_script-hashyhash")
+        assert "my_script-hashyhash.in" in injected
+        assert "my_script-hashyhash.out" in injected

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -131,7 +131,6 @@ class TestPayloadSizeLimit:
 
         # Verify error attributes
         assert exc_info.value.size_mb > 10
-        assert exc_info.value.limit_mb == 10
         assert "exceeds Globus Compute's 10 MB limit" in str(exc_info.value)
 
     def test_payload_near_limit_succeeds(self):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,5 +1,8 @@
 """Tests for the serialization module."""
 
+import pytest
+
+from groundhog_hpc.errors import PayloadTooLargeError
 from groundhog_hpc.serialization import deserialize, serialize
 
 
@@ -104,3 +107,46 @@ class TestEdgeCases:
         serialized = serialize(payload)
         deserialized = deserialize(serialized)
         assert deserialized == payload
+
+
+class TestPayloadSizeLimit:
+    """Test that payloads exceeding 10MB are rejected."""
+
+    def test_small_payload_succeeds(self):
+        """Test that payloads under 10MB serialize successfully."""
+        # Create a ~1MB payload (well under the limit)
+        large_data = "x" * (1024 * 1024)
+        result = serialize(large_data)
+        assert result is not None
+        assert deserialize(result) == large_data
+
+    def test_large_payload_raises_error(self):
+        """Test that payloads over 10MB raise PayloadTooLargeError."""
+        # Create a payload larger than 10MB
+        # Using a list of strings to exceed the limit
+        large_data = "x" * (11 * 1024 * 1024)
+
+        with pytest.raises(PayloadTooLargeError) as exc_info:
+            serialize(large_data)
+
+        # Verify error attributes
+        assert exc_info.value.size_mb > 10
+        assert exc_info.value.limit_mb == 10
+        assert "exceeds Globus Compute's 10 MB limit" in str(exc_info.value)
+
+    def test_payload_near_limit_succeeds(self):
+        """Test that payloads just under 10MB succeed."""
+        # Create a payload just under 10MB (9.5 MB)
+        large_data = "x" * (9 * 1024 * 1024 + 512 * 1024)
+        result = serialize(large_data)
+        assert result is not None
+
+    def test_pickle_payload_size_checked(self):
+        """Test that pickle-encoded payloads are also size-checked."""
+        # Create a large non-JSON-serializable object (set)
+        large_set = {i for i in range(2 * 1024 * 1024)}  # Large set
+
+        with pytest.raises(PayloadTooLargeError) as exc_info:
+            serialize(large_set)
+
+        assert exc_info.value.size_mb > 10


### PR DESCRIPTION
closes #29 

This adds a size check to `serialize` to prevent accidentally sending arguments or results >10mb, the current limit for globus compute tasks. In the future we'll want to suggest using a globus collection or something more helpful than just linking to docs 

Also cleans up the runner script slightly, and fixes some test misconfiguration (turns out our coverage is only ~45% when you exclude `tests/` 😞)