### PR TITLE
fix terminal display

### DIFF
--- a/src/groundhog_hpc/console.py
+++ b/src/groundhog_hpc/console.py
@@ -10,7 +10,6 @@ from rich.spinner import SPINNERS, Spinner
 from rich.text import Text
 
 from groundhog_hpc.compute import get_task_status
-from groundhog_hpc.errors import RemoteExecutionError
 from groundhog_hpc.future import GroundhogFuture
 
 SPINNERS["groundhog"] = {
@@ -54,8 +53,6 @@ def display_task_status(future: GroundhogFuture, poll_interval: float = 0.3) -> 
             except FuturesTimeoutError:
                 # expected - continue polling
                 continue
-            except RemoteExecutionError:
-                raise
 
 
 def _get_status_display(


### PR DESCRIPTION
the emoji flew too close to the sun and the partially cloudy emoji were inconsistent widths across different terminals. this simplifies the emoji to be just sunny vs cloudy (and moves the spinner to the right so that the entire display doesn't shift on people) 