### PR TITLE
remove unneeded harness restrictions

### DIFF
--- a/src/groundhog_hpc/app/run.py
+++ b/src/groundhog_hpc/app/run.py
@@ -87,8 +87,6 @@ def run(
             )
             raise typer.Exit(1)
 
-        # signal to harness obj that invocation is allowed
-        os.environ[f"GROUNDHOG_RUN_{harness}".upper()] = str(True)
         result = harness_func()
         typer.echo(result)
     except RemoteExecutionError as e:

--- a/src/groundhog_hpc/harness.py
+++ b/src/groundhog_hpc/harness.py
@@ -1,23 +1,19 @@
 """Harness wrapper for orchestrating remote function execution.
 
-This module provides the Harness class, which wraps entry point functions that
-orchestrate calls to remote @hog.function decorated functions. Harnesses can only
-be invoked via the CLI (`hog run script.py harness_name`) and set the necessary
-environment to allow remote function calls.
+This module provides the Harness class, which wraps zero-argument entry point
+functions that orchestrate calls to remote @hog.function decorated functions.
 """
 
 import inspect
-import os
 from types import FunctionType
 from typing import Any
 
 
 class Harness:
-    """Wrapper for an orchestrator function that coordinates remote execution.
+    """Wrapper for a zero-argument orchestrator function.
 
-    Harness functions are entry points that can call .remote() or .submit() on
-    decorated @hog.function instances. They must be invoked via the CLI and
-    cannot accept arguments.
+    Harness functions are entry points that typically coordinate calls to
+    @hog.function decorated functions. They must not accept any arguments.
 
     Attributes:
         func: The wrapped orchestrator function
@@ -38,34 +34,10 @@ class Harness:
     def __call__(self) -> Any:
         """Execute the harness function.
 
-        Sets the GROUNDHOG_IN_HARNESS environment variable to enable remote
-        function calls within the harness scope.
-
         Returns:
             The result of the harness function execution
-
-        Raises:
-            RuntimeError: If not invoked via CLI or if called from another harness
         """
-        if not self._invoked_by_cli():
-            raise RuntimeError(
-                f"Error: harness function '{self.func.__qualname__}' should only be invoked via 'hog run {self.func.__qualname__}' (and not called within the script)."
-            )
-        if self._already_in_harness():
-            raise RuntimeError(
-                f"Error: harness function '{self.func.__qualname__}' cannot be called from another harness function"
-            )
-
-        os.environ["GROUNDHOG_IN_HARNESS"] = str(True)
-        results = self.func()
-        del os.environ["GROUNDHOG_IN_HARNESS"]
-        return results
-
-    def _already_in_harness(self) -> bool:
-        return bool(os.environ.get("GROUNDHOG_IN_HARNESS"))
-
-    def _invoked_by_cli(self) -> bool:
-        return bool(os.environ.get(f"GROUNDHOG_RUN_{self.func.__qualname__}".upper()))
+        return self.func()
 
     def _validate_signature(self) -> None:
         sig = inspect.signature(self.func)

--- a/src/groundhog_hpc/utils.py
+++ b/src/groundhog_hpc/utils.py
@@ -30,16 +30,6 @@ def groundhog_script_path(script_path: Path):
         del os.environ["GROUNDHOG_SCRIPT_PATH"]
 
 
-@contextmanager
-def groundhog_in_harness():
-    """Simulate running in a @hog.harness function to enable remote execution"""
-    try:
-        os.environ["GROUNDHOG_IN_HARNESS"] = str(True)
-        yield
-    finally:
-        del os.environ["GROUNDHOG_IN_HARNESS"]
-
-
 def get_groundhog_version_spec() -> str:
     """Return the current package version spec.
 

--- a/tests/test_import_safety.py
+++ b/tests/test_import_safety.py
@@ -85,16 +85,12 @@ result = my_func.local()
 # ///
 
 import groundhog_hpc as hog
-import os
-
-# Fake being in a harness
-os.environ["GROUNDHOG_IN_HARNESS"] = "1"
 
 @hog.function(endpoint="test-endpoint")
 def my_func():
     return "hello"
 
-# This should raise an error
+# This should raise an error (no import flag set yet)
 future = my_func.submit()
 """
         script_path.write_text(script_content)
@@ -111,8 +107,6 @@ future = my_func.submit()
 
         # Cleanup
         del sys.modules["test_module3"]
-        if "GROUNDHOG_IN_HARNESS" in sys.modules.get("os", {}).environ:
-            del sys.modules["os"].environ["GROUNDHOG_IN_HARNESS"]
 
     def test_flag_allows_calls_after_import(self, tmp_path):
         """Test that .remote() calls work after import when flag is set."""

--- a/tests/test_pep723_integration.py
+++ b/tests/test_pep723_integration.py
@@ -44,13 +44,18 @@ def test_func():
         try:
             # Set up environment
             os.environ["GROUNDHOG_SCRIPT_PATH"] = script_path
-            os.environ["GROUNDHOG_IN_HARNESS"] = "True"
 
             # Create function
             def test_func():
                 return "result"
 
             func = Function(test_func, endpoint="anvil")
+
+            # Set import flag to allow remote execution
+            import sys
+
+            test_module = sys.modules[test_func.__module__]
+            test_module.__groundhog_imported__ = True
 
             # Mock the submission pipeline
             mock_shell_func = MagicMock()
@@ -94,7 +99,6 @@ def test_func():
         finally:
             Path(script_path).unlink()
             del os.environ["GROUNDHOG_SCRIPT_PATH"]
-            del os.environ["GROUNDHOG_IN_HARNESS"]
 
     def test_function_loads_pep723_variant_config(self):
         """Test that Function loads variant config with inheritance."""
@@ -125,12 +129,17 @@ def test_func():
 
         try:
             os.environ["GROUNDHOG_SCRIPT_PATH"] = script_path
-            os.environ["GROUNDHOG_IN_HARNESS"] = "True"
 
             def test_func():
                 return "result"
 
             func = Function(test_func, endpoint="anvil.gpu")
+
+            # Set import flag to allow remote execution
+            import sys
+
+            test_module = sys.modules[test_func.__module__]
+            test_module.__groundhog_imported__ = True
 
             mock_shell_func = MagicMock()
             mock_future = MagicMock()
@@ -171,7 +180,6 @@ def test_func():
         finally:
             Path(script_path).unlink()
             del os.environ["GROUNDHOG_SCRIPT_PATH"]
-            del os.environ["GROUNDHOG_IN_HARNESS"]
 
 
 class TestPep723IntegrationPrecedence:
@@ -198,7 +206,6 @@ import groundhog_hpc as hog
 
         try:
             os.environ["GROUNDHOG_SCRIPT_PATH"] = script_path
-            os.environ["GROUNDHOG_IN_HARNESS"] = "True"
 
             def test_func():
                 return "result"
@@ -207,6 +214,12 @@ import groundhog_hpc as hog
             func = Function(
                 test_func, endpoint="anvil", account="decorator-account", cores=4
             )
+
+            # Set import flag to allow remote execution
+            import sys
+
+            test_module = sys.modules[test_func.__module__]
+            test_module.__groundhog_imported__ = True
 
             mock_shell_func = MagicMock()
             mock_future = MagicMock()
@@ -247,7 +260,6 @@ import groundhog_hpc as hog
         finally:
             Path(script_path).unlink()
             del os.environ["GROUNDHOG_SCRIPT_PATH"]
-            del os.environ["GROUNDHOG_IN_HARNESS"]
 
     def test_call_time_overrides_pep723(self):
         """Test that call-time config overrides PEP 723 config."""
@@ -270,12 +282,17 @@ import groundhog_hpc as hog
 
         try:
             os.environ["GROUNDHOG_SCRIPT_PATH"] = script_path
-            os.environ["GROUNDHOG_IN_HARNESS"] = "True"
 
             def test_func():
                 return "result"
 
             func = Function(test_func, endpoint="anvil")
+
+            # Set import flag to allow remote execution
+            import sys
+
+            test_module = sys.modules[test_func.__module__]
+            test_module.__groundhog_imported__ = True
 
             mock_shell_func = MagicMock()
             mock_future = MagicMock()
@@ -313,7 +330,6 @@ import groundhog_hpc as hog
         finally:
             Path(script_path).unlink()
             del os.environ["GROUNDHOG_SCRIPT_PATH"]
-            del os.environ["GROUNDHOG_IN_HARNESS"]
 
 
 class TestPep723IntegrationWorkerInit:
@@ -339,12 +355,17 @@ import groundhog_hpc as hog
 
         try:
             os.environ["GROUNDHOG_SCRIPT_PATH"] = script_path
-            os.environ["GROUNDHOG_IN_HARNESS"] = "True"
 
             def test_func():
                 return "result"
 
             func = Function(test_func, endpoint="anvil", worker_init="pip install uv")
+
+            # Set import flag to allow remote execution
+            import sys
+
+            test_module = sys.modules[test_func.__module__]
+            test_module.__groundhog_imported__ = True
 
             mock_shell_func = MagicMock()
             mock_future = MagicMock()
@@ -378,7 +399,6 @@ import groundhog_hpc as hog
         finally:
             Path(script_path).unlink()
             del os.environ["GROUNDHOG_SCRIPT_PATH"]
-            del os.environ["GROUNDHOG_IN_HARNESS"]
 
 
 class TestPep723IntegrationRuntimeEndpointSwitch:
@@ -409,13 +429,18 @@ import groundhog_hpc as hog
 
         try:
             os.environ["GROUNDHOG_SCRIPT_PATH"] = script_path
-            os.environ["GROUNDHOG_IN_HARNESS"] = "True"
 
             def test_func():
                 return "result"
 
             # Decorator uses base 'anvil'
             func = Function(test_func, endpoint="anvil")
+
+            # Set import flag to allow remote execution
+            import sys
+
+            test_module = sys.modules[test_func.__module__]
+            test_module.__groundhog_imported__ = True
 
             mock_shell_func = MagicMock()
             mock_future = MagicMock()
@@ -453,7 +478,6 @@ import groundhog_hpc as hog
         finally:
             Path(script_path).unlink()
             del os.environ["GROUNDHOG_SCRIPT_PATH"]
-            del os.environ["GROUNDHOG_IN_HARNESS"]
 
 
 class TestPep723IntegrationRealExamples:
@@ -467,7 +491,6 @@ class TestPep723IntegrationRealExamples:
             pytest.skip("Example file not found")
 
         os.environ["GROUNDHOG_SCRIPT_PATH"] = str(example_path)
-        os.environ["GROUNDHOG_IN_HARNESS"] = "True"
 
         try:
 
@@ -475,6 +498,12 @@ class TestPep723IntegrationRealExamples:
                 return f"Hello, {name}!"
 
             func = Function(greet, endpoint="anvil")
+
+            # Set import flag (not needed for resolver tests but for consistency)
+            import sys
+
+            test_module = sys.modules[greet.__module__]
+            test_module.__groundhog_imported__ = True
 
             # Verify ConfigResolver loads the PEP 723 metadata
             resolver = func.config_resolver
@@ -487,7 +516,6 @@ class TestPep723IntegrationRealExamples:
 
         finally:
             del os.environ["GROUNDHOG_SCRIPT_PATH"]
-            del os.environ["GROUNDHOG_IN_HARNESS"]
 
     def test_hello_gpu_example_variant(self):
         """Test the hello_gpu example with variant configuration."""
@@ -497,7 +525,6 @@ class TestPep723IntegrationRealExamples:
             pytest.skip("Example file not found")
 
         os.environ["GROUNDHOG_SCRIPT_PATH"] = str(example_path)
-        os.environ["GROUNDHOG_IN_HARNESS"] = "True"
 
         try:
 
@@ -505,6 +532,12 @@ class TestPep723IntegrationRealExamples:
                 return "result"
 
             func = Function(hello_torch, endpoint="anvil.gpu-debug")
+
+            # Set import flag (not needed for resolver tests but for consistency)
+            import sys
+
+            test_module = sys.modules[hello_torch.__module__]
+            test_module.__groundhog_imported__ = True
 
             resolver = func.config_resolver
             config = resolver.resolve(
@@ -522,4 +555,3 @@ class TestPep723IntegrationRealExamples:
 
         finally:
             del os.environ["GROUNDHOG_SCRIPT_PATH"]
-            del os.environ["GROUNDHOG_IN_HARNESS"]


### PR DESCRIPTION
closes #87 

short follow up to #86 with the simplified harness logic. at this point, harnesses are just there to be targeted by `hog run` - eventually they'll do more, but users no longer _need_ them, strictly speaking. 