### PR TITLE
override exclude-newer-package for groundhog only

### DIFF
--- a/src/groundhog_hpc/templates/shell_command.sh.jinja
+++ b/src/groundhog_hpc/templates/shell_command.sh.jinja
@@ -37,10 +37,12 @@ mkdir -p "$UV_CACHE_DIR" "$UV_PYTHON_INSTALL_DIR"
 {% if log_level %}
 # Local override - use value from dispatching environment
 export GROUNDHOG_LOG_LEVEL="{{ log_level }}"
+export RUST_LOG=uv="${{GROUNDHOG_LOG_LEVEL}}"
 {% else %}
 {% raw %}
 # Respect remote environment if set, otherwise default to WARNING
 export GROUNDHOG_LOG_LEVEL="${{GROUNDHOG_LOG_LEVEL:-WARNING}}"
+export RUST_LOG=uv="${{GROUNDHOG_LOG_LEVEL:-WARNING}}"
 {% endraw %}
 {% endif %}
 
@@ -57,6 +59,7 @@ cat > {{ script_name }}.in << 'PAYLOAD_EOF'
 PAYLOAD_EOF
 
 "$UV_BIN" run --with {{ version_spec }} \
+  --exclude-newer-package groundhog-hpc={{ groundhog_timestamp }} \
   {{ runner_name }}.py
 
 echo "__GROUNDHOG_RESULT__"

--- a/src/groundhog_hpc/templating.py
+++ b/src/groundhog_hpc/templating.py
@@ -10,6 +10,7 @@ user functions remotely. It creates shell commands that:
 import logging
 import os
 import uuid
+from datetime import datetime, timezone
 from hashlib import sha1
 from pathlib import Path
 
@@ -74,6 +75,10 @@ def template_shell_command(script_path: str, function_name: str, payload: str) -
     version_spec = get_groundhog_version_spec()
     logger.debug(f"Using groundhog version spec: {version_spec}")
 
+    # Generate timestamp for groundhog-hpc exclude-newer override
+    # This allows groundhog to bypass user's exclude-newer restrictions
+    groundhog_timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
     # Load runner template
     templates_dir = Path(__file__).parent / "templates"
     jinja_env = Environment(loader=FileSystemLoader(templates_dir))
@@ -106,6 +111,7 @@ def template_shell_command(script_path: str, function_name: str, payload: str) -
         version_spec=version_spec,
         payload=payload,
         log_level=local_log_level,
+        groundhog_timestamp=groundhog_timestamp,
     )
 
     logger.debug(f"Generated shell command ({len(shell_command_string)} chars)")


### PR DESCRIPTION
fixes #123 

Previously, the `exclude-newer` timestamp would prevent the templated script from using more recent versions of groundhog (which is obvious in hindsight). However, this meant that upgrading the version of groundhog you were using would suddenly cause all older scripts to fail, since it would not be possible to install the same version of groundhog on both ends. This just adds the appropriate uv flag to allow `groundhog-hpc` and its dependents to be installed against the current time, not the `exclude-newer` time that may be present in the user's script metadata. 